### PR TITLE
Make copyright year dynamic

### DIFF
--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -10,7 +10,7 @@ const CopyRight = () => {
             Rspack is free and open source software released under the MIT
             license.
           </p>
-          <p>© 2022-present ByteDance Inc.</p>
+          <p>© {new Date().getFullYear()} ByteDance Inc.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace the static “© 2022-present ByteDance Inc.” line with a JavaScript expression that inserts the current year